### PR TITLE
Remove unneeded `use`declarations

### DIFF
--- a/src/EnvGen.php
+++ b/src/EnvGen.php
@@ -2,9 +2,6 @@
 namespace mathiasgrimm\laraveldotenvgen;
 
 use Illuminate\Console\Command;
-use Illuminate\Foundation\Inspiring;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Helper\Table;
 
 class EnvGen extends Command 


### PR DESCRIPTION
`Inspiring` references a dummy class shipped with the Laravel framework for example purpose.

The other two declarations are only useful if the command accepts arguments and/or options, which is not the case here.
