### PR TITLE
Ignore comments (fixes #10), refine name/value extraction

### DIFF
--- a/src/DotEnvGenCommand.php
+++ b/src/DotEnvGenCommand.php
@@ -114,13 +114,13 @@ class DotEnvGenCommand extends Command
         }
 
         foreach (file(base_path('.env')) as $line) {
-            if (strpos($line, '=') === false) {
+            if (strpos(trim($line), '#') === 0 || strpos($line, '=') === false) {
                 continue;
             }
 
-            preg_match('/(.+)=(.*)/', $line, $matches);
+            list($name, $value) = array_map('trim', explode('=', $line, 2));
 
-            $this->defined[$matches[1]] = $matches[2];
+            $this->defined[$name] = $value;
         }
     }
 


### PR DESCRIPTION
When scanning the .env file, it now basically mimics how phpdotenv validates each line.
